### PR TITLE
support using absolute path

### DIFF
--- a/pyzxing/reader.py
+++ b/pyzxing/reader.py
@@ -37,7 +37,7 @@ class BarCodeReader():
             self.lib_path = save_path
 
     def decode(self, filename_pattern):
-        filenames = glob.glob(filename_pattern)
+        filenames = glob.glob(os.path.abspath(filename_pattern))
         if len(filenames) == 0:
             print("File not found!")
             results = None
@@ -53,7 +53,7 @@ class BarCodeReader():
         return results
 
     def _decode(self, filename):
-        cmd = ' '.join([self.command, self.lib_path, filename, '--multi'])
+        cmd = ' '.join([self.command, self.lib_path, 'file:///' + filename, '--multi'])
         (stdout, _) = subprocess.Popen(cmd,
                                        stdout=subprocess.PIPE,
                                        universal_newlines=True,


### PR DESCRIPTION
To solve the error while decoding absolute path, I modified the _reader.py_. It will convert the relative path to an absolute path, and added "file:///" at the beginning of the path.