### PR TITLE
Use the installed conda-build entrypoint

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -458,8 +458,8 @@ jobs:
         run: |
           set -euo pipefail
           python scripts/verify_version_sync.py
-          PACKAGE_PATH=$(conda build conda-recipe --output --output-folder conda-output)
-          conda build conda-recipe --output-folder conda-output
+          PACKAGE_PATH=$(conda-build conda-recipe --output --output-folder conda-output)
+          conda-build conda-recipe --output-folder conda-output
           test -f "$PACKAGE_PATH"
           echo "PACKAGE_PATH=$PACKAGE_PATH" >> "$GITHUB_ENV"
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -315,11 +315,11 @@ jobs:
           python scripts/prepare_conda_local_recipe.py \
             --jar "runner-dist/$RUNNER_ASSET" \
             --output "$CONDA_RECIPE_COPY"
-          PACKAGE_PATH=$(conda build "$CONDA_RECIPE_COPY" \
+          PACKAGE_PATH=$(conda-build "$CONDA_RECIPE_COPY" \
             --python 3.13 \
             --output \
             --output-folder "$CONDA_OUTPUT_DIR")
-          conda build "$CONDA_RECIPE_COPY" \
+          conda-build "$CONDA_RECIPE_COPY" \
             --python 3.13 \
             --output-folder "$CONDA_OUTPUT_DIR"
           test -f "$PACKAGE_PATH"


### PR DESCRIPTION
## Summary

- invoke the pinned conda-build executable in both prepublication and release-event gates
- avoid relying on the conda build subcommand, which conda 26 did not register in the activated environment

## Verification

- git diff --check
- YAML safe-load
- actionlint 1.7.12

The live v1.2.0 publication run passed all prior gates and failed only because the conda build subcommand was not recognized after conda-build installation.