### PR TITLE
Install the staged conda source tree by path

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
   noarch: python
   number: 0
   script:
-    - {{ PYTHON }} -m pip install source --no-deps --no-build-isolation -vv
+    - {{ PYTHON }} -m pip install ./source --no-deps --no-build-isolation -vv
     - {{ PYTHON }} source/scripts/install_conda_runner.py --jar runner/{{ runner_filename }} --fixture source/src/resources/qrcode.png --prefix {{ PREFIX }}
 
 requirements:

--- a/scripts/verify_version_sync.py
+++ b/scripts/verify_version_sync.py
@@ -135,6 +135,7 @@ def main() -> int:
         "v{{ runner_version }}/{{ runner_filename }}",
         "fn: {{ runner_filename }}",
         "sha256: {{ runner_sha256 }}",
+        "{{ PYTHON }} -m pip install ./source --no-deps --no-build-isolation -vv",
     }
     for required_line in required_recipe_lines:
         if required_line not in conda_text:


### PR DESCRIPTION
## Summary

- pass ./source to pip so the offline conda build installs the staged repository directory
- assert the filesystem-path form in release metadata verification

## Verification

- synchronized release metadata check
- Ruff
- git diff --check

The live release gate successfully resolved and began the conda build, then showed that pip interpreted bare source as a package-index requirement.