### PR TITLE
Keep immutable release tags compatible with conda verification

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -458,6 +458,19 @@ jobs:
         run: |
           set -euo pipefail
           python scripts/verify_version_sync.py
+          python - conda-recipe/meta.yaml <<'PY'
+          import sys
+          from pathlib import Path
+
+          recipe = Path(sys.argv[1])
+          text = recipe.read_text(encoding="utf-8")
+          old = "{{ PYTHON }} -m pip install source --no-deps --no-build-isolation -vv"
+          new = "{{ PYTHON }} -m pip install ./source --no-deps --no-build-isolation -vv"
+          if text.count(old) == 1:
+              recipe.write_text(text.replace(old, new, 1), encoding="utf-8")
+          elif text.count(new) != 1:
+              raise SystemExit("tagged conda recipe has an unknown source install command")
+          PY
           PACKAGE_PATH=$(conda-build conda-recipe --output --output-folder conda-output)
           conda-build conda-recipe --output-folder conda-output
           test -f "$PACKAGE_PATH"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -315,6 +315,19 @@ jobs:
           python scripts/prepare_conda_local_recipe.py \
             --jar "runner-dist/$RUNNER_ASSET" \
             --output "$CONDA_RECIPE_COPY"
+          python - "$CONDA_RECIPE_COPY/meta.yaml" <<'PY'
+          import sys
+          from pathlib import Path
+
+          recipe = Path(sys.argv[1])
+          text = recipe.read_text(encoding="utf-8")
+          old = "{{ PYTHON }} -m pip install source --no-deps --no-build-isolation -vv"
+          new = "{{ PYTHON }} -m pip install ./source --no-deps --no-build-isolation -vv"
+          if text.count(old) == 1:
+              recipe.write_text(text.replace(old, new, 1), encoding="utf-8")
+          elif text.count(new) != 1:
+              raise SystemExit("temporary conda recipe has an unknown source install command")
+          PY
           PACKAGE_PATH=$(conda-build "$CONDA_RECIPE_COPY" \
             --python 3.13 \
             --output \


### PR DESCRIPTION
## Summary

- preserve the protected v1.2.0 tag at its reviewed merge commit
- normalize the known source-path typo only in ephemeral conda verification workspaces
- accept both old and already-corrected recipe forms for future releases

## Verification

- YAML safe-load
- actionlint 1.7.12
- git diff --check
- old and corrected rewrite cases

The publication checkout intentionally uses the immutable tag, so post-tag workflow fixes must not depend on moving that tag.