### PR TITLE
Create complete standalone conda smoke environments

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -479,7 +479,8 @@ jobs:
       - name: Smoke-test the installed package without jar_path
         run: |
           set -euo pipefail
-          conda create --yes --name pyzxing-conda-smoke "$PACKAGE_PATH"
+          conda create --yes --name pyzxing-conda-smoke \
+            python=3.13 numpy joblib openjdk=17 "$PACKAGE_PATH"
           conda run --name pyzxing-conda-smoke python -c "from pathlib import Path; import os; from pyzxing import BarCodeReader; root = Path(os.environ['CONDA_PREFIX']) / 'share' / 'pyzxing'; results = BarCodeReader().decode(root / 'test-data' / 'qrcode.png'); assert any(result.get('text') or result.get('raw') for result in results), results"
 
   canonical-python-distributions:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -336,7 +336,8 @@ jobs:
             --python 3.13 \
             --output-folder "$CONDA_OUTPUT_DIR"
           test -f "$PACKAGE_PATH"
-          conda create --yes --name pyzxing-conda-prepublish "$PACKAGE_PATH"
+          conda create --yes --name pyzxing-conda-prepublish \
+            python=3.13 numpy joblib openjdk=17 "$PACKAGE_PATH"
           conda run --name pyzxing-conda-prepublish python -c "from pathlib import Path; import os; from pyzxing import BarCodeReader; root = Path(os.environ['CONDA_PREFIX']) / 'share' / 'pyzxing'; results = BarCodeReader().decode(root / 'test-data' / 'qrcode.png'); assert any(result.get('text') or result.get('raw') for result in results), results"
           test "$(sha256sum conda-recipe/meta.yaml | cut -d' ' -f1)" = "$COMMITTED_RECIPE_SHA256"
           git diff --exit-code -- conda-recipe


### PR DESCRIPTION
## Summary

- keep installing the exact locally built conda artifact
- explicitly request Python 3.13, NumPy, joblib, and OpenJDK 17 because direct local package paths bypass dependency solving
- apply the same correction to prepublication and release-event smoke tests

## Verification

- live conda-build package and internal decode passed
- YAML safe-load
- actionlint 1.7.12
- git diff --check

The failed step was only the redundant standalone environment; the package's own conda-build test already completed successfully.