### PR TITLE
Install exact conda artifacts in a second transaction

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -480,7 +480,8 @@ jobs:
         run: |
           set -euo pipefail
           conda create --yes --name pyzxing-conda-smoke \
-            python=3.13 numpy joblib openjdk=17 "$PACKAGE_PATH"
+            python=3.13 numpy joblib openjdk=17
+          conda install --yes --name pyzxing-conda-smoke "$PACKAGE_PATH"
           conda run --name pyzxing-conda-smoke python -c "from pathlib import Path; import os; from pyzxing import BarCodeReader; root = Path(os.environ['CONDA_PREFIX']) / 'share' / 'pyzxing'; results = BarCodeReader().decode(root / 'test-data' / 'qrcode.png'); assert any(result.get('text') or result.get('raw') for result in results), results"
 
   canonical-python-distributions:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -337,7 +337,8 @@ jobs:
             --output-folder "$CONDA_OUTPUT_DIR"
           test -f "$PACKAGE_PATH"
           conda create --yes --name pyzxing-conda-prepublish \
-            python=3.13 numpy joblib openjdk=17 "$PACKAGE_PATH"
+            python=3.13 numpy joblib openjdk=17
+          conda install --yes --name pyzxing-conda-prepublish "$PACKAGE_PATH"
           conda run --name pyzxing-conda-prepublish python -c "from pathlib import Path; import os; from pyzxing import BarCodeReader; root = Path(os.environ['CONDA_PREFIX']) / 'share' / 'pyzxing'; results = BarCodeReader().decode(root / 'test-data' / 'qrcode.png'); assert any(result.get('text') or result.get('raw') for result in results), results"
           test "$(sha256sum conda-recipe/meta.yaml | cut -d' ' -f1)" = "$COMMITTED_RECIPE_SHA256"
           git diff --exit-code -- conda-recipe


### PR DESCRIPTION
## Summary

- solve and create the standalone runtime environment from channel package specs
- install the exact locally built conda artifact in a separate supported transaction
- keep the final no-jar-path decode in both publication and release-event workflows

## Verification

- live conda-build package and internal decode passed
- conda explicitly reported that solver specs and explicit files cannot be combined
- YAML safe-load
- actionlint 1.7.12
- git diff --check