### PR TITLE
Dispatch immutable release verification explicitly

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,13 +7,19 @@ on:
     branches: [master, main]
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing immutable release tag to verify and publish to PyPI
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.release.tag_name || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'release' }}
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' && github.event_name != 'workflow_dispatch' }}
 
 env:
   RUNNER_ARTIFACT_NAME: runner-distribution
@@ -28,6 +34,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           persist-credentials: false
 
       - name: Set up Python
@@ -46,7 +53,7 @@ jobs:
 
   java-build:
     name: Build and test Runner
-    if: github.event_name != 'release'
+    if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -54,6 +61,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           persist-credentials: false
 
       - name: Set up Python
@@ -101,7 +109,7 @@ jobs:
 
   canonical-runner:
     name: Verify canonical release Runner
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -111,7 +119,7 @@ jobs:
       - name: Check out tagged source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -129,7 +137,7 @@ jobs:
       - name: Download canonical Runner assets
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           mkdir runner-dist
           gh release download "$RELEASE_TAG" --dir runner-dist \
@@ -140,7 +148,7 @@ jobs:
 
       - name: Verify checksum, source commit, and committed configuration
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           python scripts/verify_runner_release.py \
             --jar "runner-dist/$RUNNER_ASSET_NAME" \
@@ -152,9 +160,10 @@ jobs:
       - name: Verify Java tree stayed frozen
         run: |
           RUNNER_SOURCE_COMMIT=$(tr -d '\r\n' < runner-dist/runner-source-commit.txt)
+          RELEASE_COMMIT=$(git rev-parse HEAD)
           git cat-file -e "$RUNNER_SOURCE_COMMIT^{commit}"
-          git merge-base --is-ancestor "$RUNNER_SOURCE_COMMIT" "$GITHUB_SHA"
-          git diff --exit-code "$RUNNER_SOURCE_COMMIT" "$GITHUB_SHA" -- java-runner .mvn mvnw mvnw.cmd
+          git merge-base --is-ancestor "$RUNNER_SOURCE_COMMIT" "$RELEASE_COMMIT"
+          git diff --exit-code "$RUNNER_SOURCE_COMMIT" "$RELEASE_COMMIT" -- java-runner .mvn mvnw mvnw.cmd
 
       - name: Upload verified canonical Runner
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -202,6 +211,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -252,6 +262,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           persist-credentials: false
 
       - name: Set up Python
@@ -305,6 +316,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           persist-credentials: false
 
       - name: Set up Python
@@ -349,6 +361,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ inputs.release_tag || github.ref }}
           persist-credentials: false
 
       - name: Set up Python
@@ -380,9 +393,9 @@ jobs:
         run: python -m build
 
       - name: Verify release tag matches package version
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           PACKAGE_VERSION=$(python -c "import runpy; print(runpy.run_path('pyzxing/__version__.py')['__version__'])")
           test "$RELEASE_TAG" = "v$PACKAGE_VERSION"
@@ -407,7 +420,7 @@ jobs:
           .venv-sdist/bin/python -I -c "import os; from pyzxing import BarCodeReader; results=BarCodeReader(jar_path=os.environ['PYZXING_TEST_JAR']).decode(os.environ['DECODE_FIXTURE']); assert results, results"
 
       - name: Upload Python distributions
-        if: github.event_name != 'release'
+        if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-distributions
@@ -416,7 +429,7 @@ jobs:
           retention-days: 7
 
       - name: Preserve independently rebuilt release verification distributions
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: source-built-python-distributions
@@ -426,7 +439,7 @@ jobs:
 
   conda-package-smoke:
     name: Build conda package and decode through CONDA_PREFIX
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -438,7 +451,7 @@ jobs:
       - name: Check out tagged source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
           persist-credentials: false
 
       - name: Set up pinned Miniforge
@@ -486,7 +499,7 @@ jobs:
 
   canonical-python-distributions:
     name: Verify immutable release distributions
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: [canonical-runner, conda-package-smoke]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -497,7 +510,7 @@ jobs:
       - name: Check out tagged source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
           persist-credentials: false
 
       - name: Set up Python
@@ -523,7 +536,7 @@ jobs:
       - name: Download exact immutable release distributions
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
         run: |
           set -euo pipefail
           gh release view "$RELEASE_TAG" \
@@ -581,7 +594,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: canonical-python-distributions
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -604,3 +604,24 @@ jobs:
               '.assets[] | select(.name == $name) | .digest // ""' \
               published-release-state.json)" = "$EXPECTED_DIGEST"
           done
+
+
+  dispatch:
+    name: Dispatch immutable release verification and PyPI publication
+    needs: [verify, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write # workflow_dispatch is the intentional GITHUB_TOKEN recursion exception.
+      contents: read
+
+    steps:
+      - name: Dispatch the verified immutable release
+        env:
+          DEFAULT_BRANCH: ${{ needs.verify.outputs.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          gh workflow run ci-cd.yml \
+            --ref "$DEFAULT_BRANCH" \
+            -f release_tag="$RELEASE_TAG"


### PR DESCRIPTION
## Summary

- add a release_tag workflow_dispatch path that checks out and verifies the immutable tag
- treat manual release dispatch exactly like a release event across Runner, matrix, conda, distribution, and PyPI jobs
- isolate Actions write permission in a no-checkout dispatch job after publication

## Why

GitHub intentionally suppresses ordinary workflow events created by GITHUB_TOKEN. The v1.2.0 Release is public and immutable, but its release event therefore did not start CI/CD.

## Verification

- YAML safe-load
- actionlint 1.7.12
- zizmor offline with no findings
- every checkout has an explicit event-appropriate ref
- git diff --check