### PR TITLE
Add the requested webcam demonstration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-1.2.0 (Unreleased)
+Unreleased
+- Add an OpenCV webcam demonstration that periodically samples frames through the existing one-shot `decode_array()` API
+
+1.2.0 (16 July 2026)
 - Replace ZXing's prose-oriented CLI with a versioned pyzxing JSONL Runner built on ZXing 3.5.4
 - Preserve the existing byte-valued result fields while adding text, raw bytes, byte segments, metadata, numeric points, and orientation source
 - Add `multi`, `try_harder`, `pure_barcode`, `character_set`, and `possible_formats` decode hints
@@ -12,7 +15,7 @@
 - Document exact binary/orientation semantics, frozen PyInstaller bundling, decode-only scope, and the unverified GS1 DataBar matrix that keeps issue #43 open
 - Add synchronized package/Runner/ZXing/conda metadata gates and a provenance-first workflow that publishes only a verified draft Release
 - Package the checksum-pinned canonical Runner in the conda recipe and require a real decode during conda testing
-- Defer persistent-JVM camera scanning to 1.3.0; `decode_array()` remains a one-shot API
+- Keep `decode_array()` as a one-shot API; a persistent JVM remains a separate performance optimization
 - Modernize Python 3.8-3.14, PyPI Trusted Publishing, GitHub Release, and conda-forge workflows
 
 dev (17 Jan 2022)

--- a/README.md
+++ b/README.md
@@ -201,10 +201,19 @@ from an actual one-file bundle rather than only from normal Python.
 
 ### Camera use
 
-`decode_array()` is a one-shot API: it writes a temporary image and starts one
-JVM per call. It is not a real-time camera loop. Persistent-JVM camera support
-is deferred to 1.3.0 so process lifecycle and resource cleanup can be designed
-and measured explicitly.
+The repository includes a small webcam demonstration that combines OpenCV
+camera capture with the existing one-shot `decode_array()` API. It does not
+require a persistent JVM or a new streaming API:
+
+```bash
+pip install pyzxing opencv-python
+python scripts/webcam_demo.py --camera 0 --interval 0.5
+```
+
+Press `q` or Esc to quit. Use `--possible-formats QR_CODE,DATA_MATRIX` to limit
+formats. Each sampled frame still starts one JVM, so `--interval` controls the
+trade-off between responsiveness and process overhead; this is a demonstration
+program, not a throughput claim about a persistent streaming decoder.
 
 Or you may simply call it from command line
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -185,11 +185,20 @@ reader = BarCodeReader(jar_path=runner_jar)
 CI 会冻结并执行 `scripts/pyinstaller_smoke.py`，因此该路径由真实 one-file
 程序验证，而不只是普通 Python 运行时示例。
 
-### 摄像头使用范围
+### 摄像头演示
 
-`decode_array()` 是一次性接口：每次调用都会写入临时图片并启动一个 JVM，
-不应称为实时摄像头识别。复用单一 JVM 的持久模式推迟到 1.3.0，以便单独
-设计进程生命周期、资源释放和性能指标。
+仓库提供了一个小型摄像头演示程序：使用 OpenCV 采集画面，并调用现有的
+一次性 `decode_array()` 接口抽帧识别。它不需要持久 JVM，也不需要新增
+流式 API：
+
+```bash
+pip install pyzxing opencv-python
+python scripts/webcam_demo.py --camera 0 --interval 0.5
+```
+
+按 `q` 或 Esc 退出。可用 `--possible-formats QR_CODE,DATA_MATRIX` 限定格式。
+每次抽帧识别仍会启动一个 JVM，因此 `--interval` 用来平衡响应速度与进程
+开销；这是演示程序，不代表持久流式解码器的吞吐能力。
 
 或者直接从命令行调用：
 

--- a/scripts/webcam_demo.py
+++ b/scripts/webcam_demo.py
@@ -1,0 +1,143 @@
+"""Small OpenCV webcam demonstration using pyzxing's existing one-shot API."""
+
+import argparse
+import time
+
+from pyzxing import BarCodeReader
+
+
+def _load_cv2():
+    try:
+        import cv2
+    except ImportError as exc:
+        raise RuntimeError(
+            "OpenCV is required for the webcam demo; install opencv-python"
+        ) from exc
+    return cv2
+
+
+def parse_possible_formats(value):
+    if not value:
+        return None
+    formats = [item.strip() for item in value.split(",") if item.strip()]
+    return formats or None
+
+
+def _payloads(results):
+    payloads = []
+    for result in results:
+        payload = result.get("parsed_text") or result.get("text")
+        if payload is None:
+            payload = result.get("parsed") or result.get("raw")
+        if isinstance(payload, bytes):
+            payload = payload.decode("utf-8", errors="replace")
+        if payload is not None and payload not in payloads:
+            payloads.append(payload)
+    return payloads
+
+
+def run_demo(
+    *,
+    camera=0,
+    interval=0.5,
+    multi=True,
+    try_harder=True,
+    possible_formats=None,
+    cv_module=None,
+    reader=None,
+    monotonic=time.monotonic,
+    output=print,
+):
+    """Preview a camera and periodically decode the current frame.
+
+    This deliberately composes ``cv2.VideoCapture`` with ``decode_array()``.
+    It does not add a persistent JVM or a streaming API to pyzxing.
+    """
+    if interval < 0:
+        raise ValueError("interval must be non-negative")
+
+    cv = cv_module or _load_cv2()
+    barcode_reader = reader or BarCodeReader()
+    capture = cv.VideoCapture(camera)
+    if not capture.isOpened():
+        capture.release()
+        raise RuntimeError(f"Could not open camera {camera}")
+
+    next_scan_at = 0.0
+    visible_payloads = set()
+    try:
+        while True:
+            ok, frame = capture.read()
+            if not ok:
+                raise RuntimeError(f"Could not read a frame from camera {camera}")
+
+            now = monotonic()
+            if now >= next_scan_at:
+                rgb_frame = cv.cvtColor(frame, cv.COLOR_BGR2RGB)
+                results = barcode_reader.decode_array(
+                    rgb_frame,
+                    multi=multi,
+                    try_harder=try_harder,
+                    possible_formats=possible_formats,
+                )
+                payloads = _payloads(results)
+                for payload in payloads:
+                    if payload not in visible_payloads:
+                        output(payload)
+                visible_payloads = set(payloads)
+                next_scan_at = now + interval
+
+            cv.imshow("pyzxing webcam demo (q or Esc to quit)", frame)
+            key = cv.waitKey(1) & 0xFF
+            if key in (ord("q"), 27):
+                return
+    finally:
+        capture.release()
+        cv.destroyAllWindows()
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Decode periodically sampled webcam frames with pyzxing"
+    )
+    parser.add_argument("--camera", type=int, default=0, help="OpenCV camera index")
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=0.5,
+        help="Minimum seconds between decode attempts",
+    )
+    parser.add_argument(
+        "--single",
+        action="store_true",
+        help="Return at most one barcode per sampled frame",
+    )
+    parser.add_argument(
+        "--no-try-harder",
+        action="store_true",
+        help="Disable ZXing's TRY_HARDER hint",
+    )
+    parser.add_argument(
+        "--possible-formats",
+        help="Comma-separated ZXing formats, for example QR_CODE,DATA_MATRIX",
+    )
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        run_demo(
+            camera=args.camera,
+            interval=args.interval,
+            multi=not args.single,
+            try_harder=not args.no_try_harder,
+            possible_formats=parse_possible_formats(args.possible_formats),
+        )
+    except (RuntimeError, ValueError) as exc:
+        parser.exit(1, f"error: {exc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_webcam_demo.py
+++ b/tests/test_webcam_demo.py
@@ -1,0 +1,131 @@
+from scripts import webcam_demo
+
+
+class FakeCapture:
+    def __init__(self, frames, opened=True):
+        self.frames = iter(frames)
+        self.opened = opened
+        self.released = False
+
+    def isOpened(self):
+        return self.opened
+
+    def read(self):
+        return True, next(self.frames)
+
+    def release(self):
+        self.released = True
+
+
+class FakeCV:
+    COLOR_BGR2RGB = 4
+
+    def __init__(self, capture, keys):
+        self.capture = capture
+        self.keys = iter(keys)
+        self.converted = []
+        self.shown = []
+        self.destroyed = False
+
+    def VideoCapture(self, camera):
+        self.camera = camera
+        return self.capture
+
+    def cvtColor(self, frame, conversion):
+        self.converted.append((frame, conversion))
+        return f"rgb:{frame}"
+
+    def imshow(self, title, frame):
+        self.shown.append((title, frame))
+
+    def waitKey(self, delay):
+        assert delay == 1
+        return next(self.keys)
+
+    def destroyAllWindows(self):
+        self.destroyed = True
+
+
+class FakeReader:
+    def __init__(self, results):
+        self.results = results
+        self.calls = []
+
+    def decode_array(self, frame, **kwargs):
+        self.calls.append((frame, kwargs))
+        return self.results
+
+
+def test_parse_possible_formats():
+    assert webcam_demo.parse_possible_formats(None) is None
+    assert webcam_demo.parse_possible_formats(" QR_CODE, DATA_MATRIX ") == [
+        "QR_CODE",
+        "DATA_MATRIX",
+    ]
+
+
+def test_run_demo_decodes_sampled_frame_and_releases_camera():
+    capture = FakeCapture(["frame-1"])
+    cv = FakeCV(capture, [ord("q")])
+    reader = FakeReader([{"parsed_text": "demo payload"}])
+    output = []
+
+    webcam_demo.run_demo(
+        camera=2,
+        interval=0.75,
+        multi=False,
+        try_harder=False,
+        possible_formats=["QR_CODE"],
+        cv_module=cv,
+        reader=reader,
+        monotonic=lambda: 10.0,
+        output=output.append,
+    )
+
+    assert cv.camera == 2
+    assert reader.calls == [
+        (
+            "rgb:frame-1",
+            {
+                "multi": False,
+                "try_harder": False,
+                "possible_formats": ["QR_CODE"],
+            },
+        )
+    ]
+    assert output == ["demo payload"]
+    assert capture.released
+    assert cv.destroyed
+
+
+def test_run_demo_respects_interval_between_decode_attempts():
+    capture = FakeCapture(["frame-1", "frame-2"])
+    cv = FakeCV(capture, [-1, 27])
+    reader = FakeReader([])
+    times = iter([1.0, 1.1])
+
+    webcam_demo.run_demo(
+        interval=0.5,
+        cv_module=cv,
+        reader=reader,
+        monotonic=lambda: next(times),
+    )
+
+    assert [frame for frame, _kwargs in reader.calls] == ["rgb:frame-1"]
+    assert [frame for _title, frame in cv.shown] == ["frame-1", "frame-2"]
+    assert capture.released
+    assert cv.destroyed
+
+
+def test_run_demo_reports_unavailable_camera():
+    capture = FakeCapture([], opened=False)
+    cv = FakeCV(capture, [])
+
+    try:
+        webcam_demo.run_demo(cv_module=cv, reader=FakeReader([]))
+    except RuntimeError as exc:
+        assert str(exc) == "Could not open camera 0"
+    else:
+        raise AssertionError("run_demo should reject an unavailable camera")
+
+    assert capture.released


### PR DESCRIPTION
## Summary

- add an OpenCV webcam demonstration that periodically samples frames through the existing `decode_array()` API
- keep persistent-JVM/streaming changes out of scope because issue #51 only needs a demonstration program
- document installation, controls, format filtering, and the one-JVM-per-sample performance boundary in English and Chinese
- correct the changelog’s release state and camera wording

Closes #51.

## Verification

- Python 3.8: `tests/test_webcam_demo.py` — 4 passed
- Python 3.14: full suite — 101 passed
- Ruff and `git diff --check`
- synchronized release metadata check
- wheel/sdist build and Twine check
- sdist contains the demonstration and its tests
- CLI `--help` smoke

Physical webcam hardware is not available in CI; deterministic fake capture covers the camera loop, sampling interval, format forwarding, output, and resource cleanup.