### PR TITLE
Keep the README focused on users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Unreleased
 - Publish a pyzxing-owned Runner JAR, checksum, and source commit before PyPI artifacts, and coordinate verified concurrent cache writes
 - Return one flat barcode-result list for both single-file and glob decoding
 - Isolate tests from user cache directories and add security/runtime regressions
-- Document exact binary/orientation semantics, frozen PyInstaller bundling, decode-only scope, and the unverified GS1 DataBar matrix that keeps issue #43 open
+- Document binary/orientation semantics, PyInstaller bundling, decode-only scope, and format-support boundaries
 - Add synchronized package/Runner/ZXing/conda metadata gates and a provenance-first workflow that publishes only a verified draft Release
 - Package the checksum-pinned canonical Runner in the conda recipe and require a real decode during conda testing
 - Keep `decode_array()` as a one-shot API; a persistent JVM remains a separate performance optimization

--- a/README.md
+++ b/README.md
@@ -7,29 +7,31 @@ English | [简体中文](README_CN.md)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/pyzxing)
 ![GitHub Repo stars](https://img.shields.io/github/stars/chenjiexu/pyzxing)
 
+Python bindings for the [ZXing](https://github.com/zxing/zxing) barcode decoder.
+PyZXing supports single and multiple barcodes, file globs, NumPy arrays, decode
+hints, binary payloads, result points, and orientation metadata.
 
-## First GA
+## Requirements
 
-After a year of development, the first General Availability of pyzxing is finally released. I would like to express my
-gratitude to all the developers for their suggestions and issue, which helped the development of this project to a great
-extent. This project will continue to be open source and updated regularly.
+- Python 3.8 or newer
+- Java 17 or newer on `PATH`
 
-## Introduction
-
-A Python wrapper of [ZXing library](https://github.com/zxing/zxing). python-zxing does not work properly and is out of
-maintenance. So I decide to create this repository so that Pythoneers can take advantage of ZXing library with minimum
-effort.
-
-## Features
-
-- Super easy to get hands on decoding qrcode with Python
-- Structured outputs
-- Scan multiple barcodes in one picture
-- Scan multiple pictures in parallel, which speeds up 77%
+PyZXing downloads and verifies its matching Java Runner automatically. The
+conda-forge package includes the Runner in the environment.
 
 ## Installation
 
-Installing from [Github source](https://github.com/ChenjieXu/pyzxing.git) is recommended :
+```bash
+pip install pyzxing
+```
+
+or:
+
+```bash
+conda install -c conda-forge pyzxing
+```
+
+To install the current source tree:
 
 ```bash
 git clone https://github.com/ChenjieXu/pyzxing.git
@@ -37,152 +39,96 @@ cd pyzxing
 python -m pip install .
 ```
 
-It is also possible to install from [PyPI](https://pypi.org/project/pyzxing/):
-
-```bash
-pip install pyzxing
-```
-
-Install from [Anaconda](https://anaconda.org/ChenjieXu/pyzxing). Now available on the public channel, conda-forge:
-
-```bash
-conda install -c conda-forge pyzxing # conda-forge channel
-```
-
-The 1.2 recipe packages the checksum-pinned canonical Runner under
-`$CONDA_PREFIX/share/pyzxing/runner`. `BarCodeReader()` discovers and verifies
-that copy before considering a network download; release CI builds the conda
-package and proves a default-reader decode without passing `jar_path`.
-
-## Java Runner
-
-PyZXing 1.2 uses a pyzxing-owned executable Runner built with ZXing 3.5.4 and
-requires Java 17 or newer on `PATH`. The exact JAR and its `.sha256` file are
-published with each GitHub Release. PyZXing verifies the checksum before using
-a cached or downloaded JAR.
-
-To build the Runner from source:
-
-```bash
-./mvnw -f java-runner/pom.xml clean verify
-```
-
-On Windows, use `mvnw.cmd` instead. You can bypass downloading and select a
-reviewed local build explicitly:
+## Quick start
 
 ```python
 from pyzxing import BarCodeReader
 
-reader = BarCodeReader(jar_path="/absolute/path/to/pyzxing-runner.jar")
+reader = BarCodeReader()
+
+results = reader.decode("/path/to/barcode.png")
+print(results)
+
+# Decode all matching images and return one flat result list.
+results = reader.decode("/path/to/images/*.png")
 ```
 
-## Quick Start
+Restrict formats or tune decoding with keyword arguments:
 
 ```python
-from pyzxing import BarCodeReader, DecodeError
-
-reader = BarCodeReader()
 results = reader.decode(
-    "/PATH/TO/FILE",
+    "/path/to/barcode.png",
     multi=True,
     try_harder=True,
     pure_barcode=False,
     character_set=None,
     possible_formats=["QR_CODE", "DATA_MATRIX"],
 )
-
-# A glob decodes multiple files and still returns one flat result list.
-results = reader.decode("/PATH/TO/FILES/*.png")
-print(results)
-
-# NumPy arrays require: pip install opencv-python
-results = reader.decode_array(img)
 ```
 
-Java startup failures, invalid images, and timeouts raise `DecodeError` subclasses
-instead of being reported as an empty barcode result.
+- `multi`: scan for multiple barcodes in one image.
+- `try_harder`: use ZXing's more exhaustive decode path.
+- `pure_barcode`: decode a clean, unrotated monochrome symbol.
+- `character_set`: provide a charset hint when the symbol does not carry one.
+- `possible_formats`: limit decoding to ZXing `BarcodeFormat` names.
 
-### Result schema
+## Results
 
-The 1.2 result is additive: the legacy byte-valued fields remain available,
-while the machine-readable Runner adds lossless binary and orientation fields.
+Each result is a dictionary. Common fields are:
 
 | Field | Type | Meaning |
 | --- | --- | --- |
-| `filename` | `bytes` | Exact input URI echoed by the Runner. |
-| `format`, `type` | `bytes` | Legacy ZXing format and parsed-result type. |
-| `raw`, `parsed` | `bytes` | Legacy UTF-8 encodings of `text` and `parsed_text`. |
-| `text`, `parsed_text` | `str` | Decoded text and ZXing's parsed display text. |
-| `raw_bytes` | `bytes \| None` | ZXing raw result bytes; for QR this is not necessarily the original byte-mode payload. |
-| `byte_segments` | `list[bytes]` | Lossless BYTE-mode payload segments, in order. |
-| `num_bits` | `int \| None` | Valid bit count in `raw_bytes`. |
-| `points` | `list[tuple[float, float]]` | ZXing result points as `(x, y)` pairs. |
-| `orientation` | `0 \| 90 \| 180 \| 270 \| None` | Clockwise rotation from upright. |
-| `orientation_source` | `str` | `metadata`, QR-only `derived`, or `unavailable`. |
-| `metadata` | `dict` | Stable allow-listed metadata, including symbology/error-correction fields when available. |
+| `filename` | `bytes` | Input file URI. |
+| `format`, `type` | `bytes` | Barcode format and parsed-result type. |
+| `raw`, `parsed` | `bytes` | Backward-compatible text fields. |
+| `text`, `parsed_text` | `str` | Decoded and parsed display text. |
+| `raw_bytes` | `bytes \| None` | ZXing raw result bytes. |
+| `byte_segments` | `list[bytes]` | Lossless byte-mode payload segments. |
+| `points` | `list[tuple[float, float]]` | Result points as `(x, y)` pairs. |
+| `orientation` | `0 \| 90 \| 180 \| 270 \| None` | Clockwise image rotation. |
+| `orientation_source` | `str` | `metadata`, `derived`, or `unavailable`. |
+| `metadata` | `dict` | Stable ZXing metadata when available. |
 
-For binary QR data, use `byte_segments`; do not recover bytes by re-encoding
-`text`. `raw_bytes` and `byte_segments` intentionally expose different ZXing
-concepts. A no-barcode image retains the 1.x compatibility placeholder
-containing only `filename`.
+For binary QR data, use `byte_segments` instead of re-encoding `text`.
+Decode and runtime failures raise `DecodeError` subclasses.
 
-`orientation_source` is part of the meaning. The top-level `orientation` is
-always normalized to the image's clockwise rotation from upright. For 1D
-formats, `metadata.orientation` preserves ZXing's raw counter-clockwise
-correction value, so a clockwise-90 image has top-level `orientation=90` while
-raw metadata may be `270`. ZXing does not supply QR orientation metadata, so
-`derived` QR values use the geometric clockwise angle of ordered finder points.
-If that geometry is insufficient, the value is `None` rather than a guess.
-Metadata may also include integer
-`errors_corrected` and `erasures_corrected` values when ZXing provides them.
+## NumPy arrays
 
-Runner stdout is protocol schema version 1. Error codes are enum-like protocol
-values: adding, renaming, or removing a Java error code requires matching Python
-validation/tests and an explicit schema-version compatibility review. Unknown
-codes are rejected instead of being silently accepted.
-
-### Decode hints and format scope
-
-- `multi` scans for more than one barcode in an image.
-- `try_harder` enables ZXing's more exhaustive path.
-- `pure_barcode` is for an unrotated, monochrome barcode image without surrounding content.
-- `character_set` supplies a charset hint such as `GB18030` when the symbol does not carry one.
-- `possible_formats` accepts ZXing 3.5.4 `BarcodeFormat` names and restricts decoding to those formats.
-
-For issue #34's committed no-ECI fixture, the default decoder preserves the
-exact GB18030 bytes in `byte_segments` but cannot infer the intended text
-encoding; `character_set="GB18030"` returns the expected Chinese text. For
-issue #38's exact 192-value corpus, the recorded ZXing 3.5.4 Runner decodes
-23/192 in default/try-harder/QR-only modes and 192/192 with
-`pure_barcode=True`. ZXing 3.4.1 decoded 19/192 by default and also 192/192 in
-pure-barcode mode. The upgrade is therefore not presented as a general detector
-fix; the committed reports preserve the limitation and the proven hint.
-
-PyZXing is a decoder, not a QR generator; use a library such as
-[Segno](https://segno.readthedocs.io/) for generation. The exact status of the
-six GS1 variants requested in issue #43 is:
-
-| Requested variant | Candidate ZXing 3.5.4 route | Committed project fixture | 1.2 status |
-| --- | --- | --- | --- |
-| GS1 DataBar Expanded | `RSS_EXPANDED` | None | Unverified |
-| GS1 DataBar Expanded Stacked | `RSS_EXPANDED` | None | Unverified |
-| GS1 DataBar OmniDirectional | `RSS_14` | None | Unverified |
-| GS1 DataBar Stacked | `RSS_14` | None | Unverified |
-| GS1 DataBar Stacked Omnidirectional | `RSS_14` | None | Unverified |
-| GS1 DataBar Truncated | `RSS_14` | None | Unverified |
-
-Generic QR and Code 128 fixtures do not prove these DataBar variants. The
-Runner exposes ZXing's `symbology_identifier` metadata when present, but that is
-not application-level GS1 validation. Issue #43 stays open until each claimed
-variant has a redistributable fixture and an asserted payload result.
-
-### PyInstaller
-
-Bundle the exact release Runner and pass its unpacked path explicitly:
+Install OpenCV and pass an RGB or grayscale array:
 
 ```bash
-# Linux and macOS; use `;runner` instead of `:runner` on Windows.
-pyinstaller --add-data "/absolute/path/to/pyzxing-runner.jar:runner" app.py
+pip install opencv-python
+```
+
+```python
+results = reader.decode_array(image)
+```
+
+## Webcam demo
+
+The example periodically samples frames from an OpenCV camera:
+
+```bash
+pip install pyzxing opencv-python
+python scripts/webcam_demo.py --camera 0 --interval 0.5
+```
+
+Press `q` or Esc to quit. Run `python scripts/webcam_demo.py --help` for all
+options.
+
+## Command line
+
+```bash
+python scripts/scanner.py -f /path/to/barcode.png
+```
+
+## PyInstaller
+
+Bundle a Runner JAR and pass its extracted path to `BarCodeReader`:
+
+```bash
+# Use `;runner` instead of `:runner` on Windows.
+pyinstaller --add-data "/path/to/pyzxing-runner.jar:runner" app.py
 ```
 
 ```python
@@ -196,31 +142,11 @@ runner_jar = next((bundle_dir / "runner").glob("*.jar"))
 reader = BarCodeReader(jar_path=runner_jar)
 ```
 
-CI freezes and executes `scripts/pyinstaller_smoke.py`, so this path is tested
-from an actual one-file bundle rather than only from normal Python.
-
-### Camera use
-
-The repository includes a small webcam demonstration that combines OpenCV
-camera capture with the existing one-shot `decode_array()` API. It does not
-require a persistent JVM or a new streaming API:
+## Development
 
 ```bash
-pip install pyzxing opencv-python
-python scripts/webcam_demo.py --camera 0 --interval 0.5
+./mvnw -f java-runner/pom.xml clean verify
+python -m pytest tests/
 ```
 
-Press `q` or Esc to quit. Use `--possible-formats QR_CODE,DATA_MATRIX` to limit
-formats. Each sampled frame still starts one JVM, so `--interval` controls the
-trade-off between responsiveness and process overhead; this is a demonstration
-program, not a throughput claim about a persistent streaming decoder.
-
-Or you may simply call it from command line
-
-```bash
-python scripts/scanner.py -f /PATH/TO/FILE
-```
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=chenjiexu/pyzxing&type=Date)](https://www.star-history.com/#chenjiexu/pyzxing&Date)
+Windows users can run `mvnw.cmd` instead of `./mvnw`.

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,24 +7,31 @@
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/pyzxing)
 ![GitHub Repo stars](https://img.shields.io/github/stars/chenjiexu/pyzxing)
 
-## 第一个正式版本
+[ZXing](https://github.com/zxing/zxing) 条码解码器的 Python 封装。PyZXing
+支持单码和多码识别、文件通配符、NumPy 数组、解码提示、二进制数据、定位点
+和方向元数据。
 
-经历了一年的开发，pyzxing的第一个正式版本终于发布了。十分感谢各位开发者的建议和issue，这非常大程度上帮助了这个项目的开发。这个项目会继续保持开源并定时更新。
+## 环境要求
 
-## 简介
+- Python 3.8 或更高版本
+- 系统 `PATH` 中提供 Java 17 或更高版本
 
-Pyzxing是二维码识别[ZXing](https://github.com/zxing/zxing) JAVA库的Python
-API。由于Zxing库相较于其他库二维码识别率最高，但使用起来十分繁琐，且python-zxing不能正常使用且已不再维护，所以我创建了这个库让使用Python的人可以花费最小的精力来使用Zxing库来进行二维码识别。
-
-## 特性
-
-- 十分容易上手
-- 结构化输出
-- 能够识别一张图中的多个二维码
-- 以并行方式识别多张图片，提速77%
+PyZXing 会自动下载并校验匹配的 Java Runner；conda-forge 包会将 Runner
+直接安装到环境中。
 
 ## 安装
-推荐从[Github](https://github.com/ChenjieXu/pyzxing.git) 源安装:
+
+```bash
+pip install pyzxing
+```
+
+或者：
+
+```bash
+conda install -c conda-forge pyzxing
+```
+
+安装当前源码：
 
 ```bash
 git clone https://github.com/ChenjieXu/pyzxing.git
@@ -32,143 +39,95 @@ cd pyzxing
 python -m pip install .
 ```
 
-同时也支持使用pip从 [PyPI](https://pypi.org/project/pyzxing/) 安装:
-
-```bash
-pip install pyzxing
-```
-
-从[Anaconda](https://anaconda.org/ChenjieXu/pyzxing) 安装。现在可以从公开的channel——conda-forge中下载:
-
-```bash
-conda install -c conda-forge pyzxing # conda-forge频道
-```
-
-1.2 recipe 会把 checksum 固定的 canonical Runner 安装到
-`$CONDA_PREFIX/share/pyzxing/runner`。`BarCodeReader()` 会先发现并校验这份
-文件，再考虑联网下载；Release CI 会实际构建 conda 包，并在不传
-`jar_path` 的情况下验证默认 reader 解码。
-
-## Java Runner
-
-PyZXing 1.2 使用由本项目维护、基于 ZXing 3.5.4 的可执行 Runner，要求
-系统 `PATH` 中提供 Java 17 或更高版本。每个 GitHub Release 会同时发布
-确定的 JAR 与 `.sha256` 文件；使用缓存或下载文件前都会校验 SHA-256。
-
-从源码构建 Runner：
-
-```bash
-./mvnw -f java-runner/pom.xml clean verify
-```
-
-Windows 请使用 `mvnw.cmd`。也可以显式选择已经审核的本地 JAR：
+## 快速上手
 
 ```python
 from pyzxing import BarCodeReader
 
-reader = BarCodeReader(jar_path="/absolute/path/to/pyzxing-runner.jar")
+reader = BarCodeReader()
+
+results = reader.decode("/path/to/barcode.png")
+print(results)
+
+# 识别所有匹配图片，并返回一层结果列表。
+results = reader.decode("/path/to/images/*.png")
 ```
 
-## 快速上手
+可通过参数限制格式或调整解码方式：
 
 ```python
-from pyzxing import BarCodeReader, DecodeError
-
-reader = BarCodeReader()
 results = reader.decode(
-    "/PATH/TO/FILE",
+    "/path/to/barcode.png",
     multi=True,
     try_harder=True,
     pure_barcode=False,
     character_set=None,
     possible_formats=["QR_CODE", "DATA_MATRIX"],
 )
-
-# glob 可以识别多个文件，仍然返回一层扁平结果列表。
-results = reader.decode("/PATH/TO/FILES/*.png")
-print(results)
-
-# NumPy 数组需要先安装：pip install opencv-python
-results = reader.decode_array(img)
 ```
 
-Java 启动失败、无效图片和超时会抛出 `DecodeError` 的具体子类，
-不再伪装成空的条码结果。
+- `multi`：识别一张图片中的多个条码。
+- `try_harder`：启用 ZXing 更全面的解码路径。
+- `pure_barcode`：解码干净、未旋转的纯单色条码。
+- `character_set`：条码未携带字符集时提供字符集提示。
+- `possible_formats`：限制为指定的 ZXing `BarcodeFormat` 名称。
 
-### 返回字段
+## 返回结果
 
-1.2 采用增量兼容策略：保留原有 bytes 字段，同时增加无损二进制和方向字段。
+每个结果都是一个字典，常用字段如下：
 
 | 字段 | 类型 | 含义 |
 | --- | --- | --- |
-| `filename` | `bytes` | Runner 原样返回的输入 URI。 |
-| `format`, `type` | `bytes` | 兼容字段：ZXing 格式与解析结果类型。 |
-| `raw`, `parsed` | `bytes` | `text`、`parsed_text` 的 UTF-8 兼容表示。 |
-| `text`, `parsed_text` | `str` | 解码文本与 ZXing 的展示文本。 |
-| `raw_bytes` | `bytes \| None` | ZXing 原始结果字节；对 QR 而言不一定等于原始 BYTE 段。 |
-| `byte_segments` | `list[bytes]` | 按顺序保存的无损 BYTE 模式数据段。 |
-| `num_bits` | `int \| None` | `raw_bytes` 中有效的位数。 |
-| `points` | `list[tuple[float, float]]` | ZXing 返回的 `(x, y)` 定位点。 |
-| `orientation` | `0 \| 90 \| 180 \| 270 \| None` | 相对正向的顺时针旋转角度。 |
-| `orientation_source` | `str` | `metadata`、仅 QR 使用的 `derived`，或 `unavailable`。 |
-| `metadata` | `dict` | 经过白名单约束的稳定元数据，包括可用的码制和纠错字段。 |
+| `filename` | `bytes` | 输入文件 URI。 |
+| `format`, `type` | `bytes` | 条码格式和解析结果类型。 |
+| `raw`, `parsed` | `bytes` | 向后兼容的文本字段。 |
+| `text`, `parsed_text` | `str` | 解码文本和解析后的展示文本。 |
+| `raw_bytes` | `bytes \| None` | ZXing 原始结果字节。 |
+| `byte_segments` | `list[bytes]` | 无损字节模式数据段。 |
+| `points` | `list[tuple[float, float]]` | `(x, y)` 定位点。 |
+| `orientation` | `0 \| 90 \| 180 \| 270 \| None` | 图片的顺时针旋转角度。 |
+| `orientation_source` | `str` | `metadata`、`derived` 或 `unavailable`。 |
+| `metadata` | `dict` | ZXing 提供的稳定元数据。 |
 
-处理二进制 QR 时应直接使用 `byte_segments`，不要把 `text` 重新编码来恢复
-原始数据。`raw_bytes` 与 `byte_segments` 对应 ZXing 中两个不同的概念。
-未发现条码时，1.x 的兼容行为仍会返回只包含 `filename` 的占位结果。
+处理二进制 QR 数据时应使用 `byte_segments`，不要重新编码 `text`。
+解码和运行时失败会抛出 `DecodeError` 的具体子类。
 
-方向必须结合 `orientation_source` 理解。顶层 `orientation` 统一表示图片相对
-正向的顺时针旋转角度。对一维码，`metadata.orientation` 保留 ZXing 原始的
-逆时针纠正角度，因此顺时针旋转 90 度的图片会得到顶层 `orientation=90`，
-而原始 metadata 可能是 `270`。ZXing 不为 QR 提供方向元数据，因此
-`derived` QR 值采用有序定位点的几何顺时针角度；定位点不足时返回 `None`，
-不会猜测。ZXing 提供时，metadata 还可能包含整数类型的
-`errors_corrected` 和 `erasures_corrected`。
+## NumPy 数组
 
-Runner stdout 使用协议 schema version 1。错误码属于枚举式协议值：Java
-新增、重命名或删除错误码时，必须同步 Python 校验和测试，并明确评估是否
-需要升级 schema version；未知错误码会被拒绝，不会静默放行。
-
-### 解码提示和格式范围
-
-- `multi`：在一张图片中扫描多个条码。
-- `try_harder`：启用 ZXing 更全面的扫描路径。
-- `pure_barcode`：仅适用于没有周边内容、未旋转的纯单色条码图片。
-- `character_set`：条码没有携带字符集时，可传入 `GB18030` 等提示。
-- `possible_formats`：传入 ZXing 3.5.4 的 `BarcodeFormat` 名称以限制格式。
-
-对 issue #34 已提交的无 ECI 样本，默认解码仍会在 `byte_segments` 中无损
-保留 GB18030 字节，但无法自动推断文本编码；传入
-`character_set="GB18030"` 后可得到预期中文。对 issue #38 的精确 192 个值，
-记录中的 ZXing 3.5.4 Runner 在 default/try-harder/QR-only 模式识别 23/192，
-使用 `pure_barcode=True` 时识别 192/192；ZXing 3.4.1 默认识别 19/192，
-pure-barcode 同样是 192/192。因此不能把升级描述成通用检测修复；已提交报告
-保留了该限制和经过验证的 hint。
-
-PyZXing 只负责解码，不提供二维码生成；生成二维码可使用
-[Segno](https://segno.readthedocs.io/)。issue #43 请求的六种 GS1 变体当前
-状态如下：
-
-| 请求的变体 | ZXing 3.5.4 候选入口 | 项目内已提交样本 | 1.2 状态 |
-| --- | --- | --- | --- |
-| GS1 DataBar Expanded | `RSS_EXPANDED` | 无 | 未验证 |
-| GS1 DataBar Expanded Stacked | `RSS_EXPANDED` | 无 | 未验证 |
-| GS1 DataBar OmniDirectional | `RSS_14` | 无 | 未验证 |
-| GS1 DataBar Stacked | `RSS_14` | 无 | 未验证 |
-| GS1 DataBar Stacked Omnidirectional | `RSS_14` | 无 | 未验证 |
-| GS1 DataBar Truncated | `RSS_14` | 无 | 未验证 |
-
-普通 QR 和 Code 128 样本不能证明这些 DataBar 变体。Runner 会在 ZXing
-提供时暴露 `symbology_identifier`，但这不等于应用层 GS1 校验。在每个声称
-支持的变体都有可再分发样本和预期 payload 断言前，issue #43 保持开启。
-
-### PyInstaller
-
-将对应 Release 的 Runner 打包，并显式传入解压后的路径：
+安装 OpenCV，然后传入 RGB 或灰度数组：
 
 ```bash
-# Linux 和 macOS；Windows 将 `:runner` 改为 `;runner`。
-pyinstaller --add-data "/absolute/path/to/pyzxing-runner.jar:runner" app.py
+pip install opencv-python
+```
+
+```python
+results = reader.decode_array(image)
+```
+
+## 摄像头演示
+
+示例程序会定期抽取 OpenCV 摄像头画面进行识别：
+
+```bash
+pip install pyzxing opencv-python
+python scripts/webcam_demo.py --camera 0 --interval 0.5
+```
+
+按 `q` 或 Esc 退出。运行 `python scripts/webcam_demo.py --help` 查看全部参数。
+
+## 命令行
+
+```bash
+python scripts/scanner.py -f /path/to/barcode.png
+```
+
+## PyInstaller
+
+将 Runner JAR 打包，并把解压后的路径传给 `BarCodeReader`：
+
+```bash
+# Windows 使用 `;runner`，不要使用 `:runner`。
+pyinstaller --add-data "/path/to/pyzxing-runner.jar:runner" app.py
 ```
 
 ```python
@@ -182,30 +141,11 @@ runner_jar = next((bundle_dir / "runner").glob("*.jar"))
 reader = BarCodeReader(jar_path=runner_jar)
 ```
 
-CI 会冻结并执行 `scripts/pyinstaller_smoke.py`，因此该路径由真实 one-file
-程序验证，而不只是普通 Python 运行时示例。
-
-### 摄像头演示
-
-仓库提供了一个小型摄像头演示程序：使用 OpenCV 采集画面，并调用现有的
-一次性 `decode_array()` 接口抽帧识别。它不需要持久 JVM，也不需要新增
-流式 API：
+## 开发
 
 ```bash
-pip install pyzxing opencv-python
-python scripts/webcam_demo.py --camera 0 --interval 0.5
+./mvnw -f java-runner/pom.xml clean verify
+python -m pytest tests/
 ```
 
-按 `q` 或 Esc 退出。可用 `--possible-formats QR_CODE,DATA_MATRIX` 限定格式。
-每次抽帧识别仍会启动一个 JVM，因此 `--interval` 用来平衡响应速度与进程
-开销；这是演示程序，不代表持久流式解码器的吞吐能力。
-
-或者直接从命令行调用：
-
-```bash
-python scripts/scanner.py -f /PATH/TO/FILE
-```
-
-## 点赞趋势
-
-[![Star History Chart](https://api.star-history.com/svg?repos=chenjiexu/pyzxing&type=Date)](https://www.star-history.com/#chenjiexu/pyzxing&Date)
+Windows 用户使用 `mvnw.cmd` 代替 `./mvnw`。


### PR DESCRIPTION
## Summary
- remove issue-specific investigations and evidence from both READMEs
- remove benchmark, CI self-proof, and release-internal prose
- keep installation, API, result schema, examples, and development commands

## Verification
- version synchronization check
- Ruff
- 101 pytest tests
- wheel and sdist build
- Twine package check
- git diff check