### PR TITLE
Prepare the v1.2.1 Jackson security release

### DIFF
--- a/.github/workflows/prepare-runner.yml
+++ b/.github/workflows/prepare-runner.yml
@@ -10,7 +10,7 @@ on:
       release_tag:
         description: Draft GitHub release tag to prepare
         required: true
-        default: v1.2.0
+        default: v1.2.1
         type: string
   pull_request:
     branches:

--- a/.github/workflows/prepare-runner.yml
+++ b/.github/workflows/prepare-runner.yml
@@ -196,6 +196,7 @@ jobs:
     permissions:
       contents: write # Required to create the draft Release and upload canonical assets.
     env:
+      GH_REPO: ${{ github.repository }}
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
       SOURCE_COMMIT: ${{ needs.resolve-release.outputs.source_commit }}
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ on:
       release_tag:
         description: Existing tag and draft GitHub release to publish
         required: true
-        default: v1.2.0
+        default: v1.2.1
         type: string
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 Unreleased
+
+1.2.1 (17 July 2026)
+- Upgrade the bundled Jackson Databind runtime to 2.18.9 to address two high- and two medium-severity security advisories
 - Add an OpenCV webcam demonstration that periodically samples frames through the existing one-shot `decode_array()` API
 
 1.2.0 (16 July 2026)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -3,8 +3,8 @@
 {% set runner_version = "1.2.1" %}
 {% set zxing_version = "3.5.4" %}
 {% set runner_filename = "pyzxing-runner-1.2.1-zxing-3.5.4.jar" %}
-{% set runner_sha256 = "0000000000000000000000000000000000000000000000000000000000000000" %}
-{% set runner_source_commit = "" %}
+{% set runner_sha256 = "4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565" %}
+{% set runner_source_commit = "4e94d9d61fc0dbe7c4616a620ee961d3a3f2c438" %}
 
 package:
   name: {{ name|lower }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 {% set name = "pyzxing" %}
-{% set version = "1.2.0" %}
-{% set runner_version = "1.2.0" %}
+{% set version = "1.2.1" %}
+{% set runner_version = "1.2.1" %}
 {% set zxing_version = "3.5.4" %}
-{% set runner_filename = "pyzxing-runner-1.2.0-zxing-3.5.4.jar" %}
-{% set runner_sha256 = "d542daf2b3af3405ed5f949542acb287e176a3cdfd119edb504079c3033cd9cb" %}
-{% set runner_source_commit = "a95adc59b671de82f339983f8324306078d55c18" %}
+{% set runner_filename = "pyzxing-runner-1.2.1-zxing-3.5.4.jar" %}
+{% set runner_sha256 = "0000000000000000000000000000000000000000000000000000000000000000" %}
+{% set runner_source_commit = "" %}
 
 package:
   name: {{ name|lower }}

--- a/java-runner/pom.xml
+++ b/java-runner/pom.xml
@@ -6,17 +6,17 @@
 
   <groupId>io.github.chenjiexu</groupId>
   <artifactId>pyzxing-runner</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <name>pyzxing JSONL Runner</name>
   <description>Machine-readable ZXing runner for pyzxing</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.build.outputTimestamp>2026-07-16T00:00:00Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-07-17T00:00:00Z</project.build.outputTimestamp>
     <maven.compiler.release>17</maven.compiler.release>
     <zxing.version>3.5.4</zxing.version>
-    <jackson.version>2.18.4</jackson.version>
+    <jackson.version>2.18.9</jackson.version>
     <junit.version>5.11.4</junit.version>
   </properties>
 

--- a/pyzxing/__version__.py
+++ b/pyzxing/__version__.py
@@ -1,6 +1,6 @@
 """Version information for pyzxing package."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 # For backward compatibility
 VERSION = __version__

--- a/pyzxing/config.py
+++ b/pyzxing/config.py
@@ -20,8 +20,8 @@ class Config:
     JAR_URL_PREFIX = "https://github.com/ChenjieXu/pyzxing/releases/download/v{version}/"
     JAR_FILENAME = "pyzxing-runner-1.2.1-zxing-3.5.4.jar"
     # PRE-RELEASE GATE: replace both placeholders from the canonical draft asset.
-    JAR_SHA256 = "0000000000000000000000000000000000000000000000000000000000000000"
-    RUNNER_SOURCE_COMMIT = ""
+    JAR_SHA256 = "4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565"
+    RUNNER_SOURCE_COMMIT = "4e94d9d61fc0dbe7c4616a620ee961d3a3f2c438"
     
     # Performance settings
     PARALLEL_THRESHOLD = 3  # Files below this count use sequential processing

--- a/pyzxing/config.py
+++ b/pyzxing/config.py
@@ -14,14 +14,14 @@ class Config:
     MIN_PYTHON_VERSION = '>=3.8.0'
     
     # pyzxing Runner / ZXing settings
-    RUNNER_VERSION = '1.2.0'
+    RUNNER_VERSION = '1.2.1'
     DEFAULT_ZXING_VERSION = '3.5.4'
     JAR_RELEASE_VERSION = RUNNER_VERSION
     JAR_URL_PREFIX = "https://github.com/ChenjieXu/pyzxing/releases/download/v{version}/"
-    JAR_FILENAME = "pyzxing-runner-1.2.0-zxing-3.5.4.jar"
+    JAR_FILENAME = "pyzxing-runner-1.2.1-zxing-3.5.4.jar"
     # PRE-RELEASE GATE: replace both placeholders from the canonical draft asset.
-    JAR_SHA256 = "d542daf2b3af3405ed5f949542acb287e176a3cdfd119edb504079c3033cd9cb"
-    RUNNER_SOURCE_COMMIT = "a95adc59b671de82f339983f8324306078d55c18"
+    JAR_SHA256 = "0000000000000000000000000000000000000000000000000000000000000000"
+    RUNNER_SOURCE_COMMIT = ""
     
     # Performance settings
     PARALLEL_THRESHOLD = 3  # Files below this count use sequential processing

--- a/reports/issue-34-gb18030.json
+++ b/reports/issue-34-gb18030.json
@@ -28,10 +28,10 @@
     "payload_hex": "c9fab2fad0edbfc9d6a4bac5a3bab2e2cad42d313233"
   },
   "decoder": {
-    "runner_version": "1.2.0",
+    "runner_version": "1.2.1",
     "zxing_version": "3.5.4",
-    "artifact": "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
-    "artifact_sha256": "d542daf2b3af3405ed5f949542acb287e176a3cdfd119edb504079c3033cd9cb",
+    "artifact": "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+    "artifact_sha256": "4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565",
     "java": "openjdk 17.0.19"
   },
   "cases": {

--- a/reports/issue-35-assessment.json
+++ b/reports/issue-35-assessment.json
@@ -69,10 +69,10 @@
   ],
   "attachment_retention": "source_url_and_sha256_only_not_committed",
   "decoder": {
-    "runner_version": "1.2.0",
+    "runner_version": "1.2.1",
     "zxing_version": "3.5.4",
-    "artifact": "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
-    "artifact_sha256": "d542daf2b3af3405ed5f949542acb287e176a3cdfd119edb504079c3033cd9cb",
+    "artifact": "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+    "artifact_sha256": "4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565",
     "protocol": "UTF-8 JSONL schema_version 1"
   },
   "hint_matrix": {
@@ -80,7 +80,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
         "{attachment_file_uri}"
       ],
       "hints": {
@@ -94,7 +94,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--try-harder"
       ],
@@ -109,7 +109,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--possible-formats",
         "CODE_39"
@@ -127,7 +127,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--try-harder",
         "--possible-formats",
@@ -146,7 +146,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--pure-barcode"
       ],
@@ -161,7 +161,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--multi",
         "--try-harder"
@@ -177,7 +177,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--multi",
         "--try-harder",

--- a/reports/issue-38-zxing-comparison.json
+++ b/reports/issue-38-zxing-comparison.json
@@ -1038,35 +1038,35 @@
     },
     "zxing_3_5_4": {
       "zxing_version": "3.5.4",
-      "runner_version": "1.2.0",
+      "runner_version": "1.2.1",
       "protocol": "UTF-8 JSONL schema_version 1",
-      "artifact": "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
-      "artifact_sha256": "d542daf2b3af3405ed5f949542acb287e176a3cdfd119edb504079c3033cd9cb",
+      "artifact": "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+      "artifact_sha256": "4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565",
       "commands": {
         "default": [
           "java",
           "-jar",
-          "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+          "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
           "{input_uri}"
         ],
         "try_harder": [
           "java",
           "-jar",
-          "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+          "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
           "{input_uri}",
           "--try-harder"
         ],
         "pure_barcode": [
           "java",
           "-jar",
-          "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+          "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
           "{input_uri}",
           "--pure-barcode"
         ],
         "qr_only": [
           "java",
           "-jar",
-          "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+          "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
           "{input_uri}",
           "--possible-formats",
           "QR_CODE"
@@ -1074,7 +1074,7 @@
         "wrapper_defaults": [
           "java",
           "-jar",
-          "pyzxing-runner-1.2.0-zxing-3.5.4.jar",
+          "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
           "{input_uri}",
           "--multi",
           "--try-harder"

--- a/tests/test_create_reader.py
+++ b/tests/test_create_reader.py
@@ -50,12 +50,12 @@ def test_missing_java_has_actionable_error(monkeypatch, tmp_path):
 
 
 def test_runner_release_coordinates_are_versioned():
-    assert Config.RUNNER_VERSION == "1.2.0"
+    assert Config.RUNNER_VERSION == "1.2.1"
     assert Config.DEFAULT_ZXING_VERSION == "3.5.4"
-    assert Config.JAR_FILENAME == "pyzxing-runner-1.2.0-zxing-3.5.4.jar"
+    assert Config.JAR_FILENAME == "pyzxing-runner-1.2.1-zxing-3.5.4.jar"
     assert Config.get_jar_url() == (
-        "https://github.com/ChenjieXu/pyzxing/releases/download/v1.2.0/"
-        "pyzxing-runner-1.2.0-zxing-3.5.4.jar"
+        "https://github.com/ChenjieXu/pyzxing/releases/download/v1.2.1/"
+        "pyzxing-runner-1.2.1-zxing-3.5.4.jar"
     )
 
 


### PR DESCRIPTION
## Summary

- upgrade the bundled Jackson Databind, Core, and Annotations runtime to 2.18.9
- resolve the two high- and two medium-severity Dependabot alerts through a project-owned v1.2.1 release
- synchronize package, Runner, conda, workflow, changelog, tests, and durable evidence
- supersede automated PR #53 without bringing its bot-authored commit into master

## Canonical Runner

Frozen source commit:

`4e94d9d61fc0dbe7c4616a620ee961d3a3f2c438`

Canonical Runner:

`pyzxing-runner-1.2.1-zxing-3.5.4.jar`

`sha256:4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565`

GitHub and local clean builds produced byte-identical artifacts. The staging draft contains exactly the JAR, checksum, source-commit record, and reproducibility record; all four GitHub server digests and sizes match the canonical local files. Final metadata contains no placeholders, and the frozen Java/Maven paths are unchanged after the source commit.

## Verification

- two local and two GitHub clean Maven builds
- 11 JUnit tests
- 101 pytest tests with 80% coverage
- strict Runner, version, and durable release-evidence verification
- Ruff
- wheel and source distribution build
- Twine
- zizmor
- YAML parse
- git diff check

Local actionlint installation was unavailable because the Go module download timed out; GitHub PR CI provides the workflow parser and execution gate.