### PR TITLE
Keep release dispatch repository-aware

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -620,6 +620,7 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ needs.verify.outputs.default_branch }}
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           gh workflow run ci-cd.yml \


### PR DESCRIPTION
Adds the missing `GH_REPO` environment value to the checkout-free release dispatch job.

The v1.2.1 publication exposed this because `gh workflow run` otherwise tried to discover a repository from a nonexistent checkout. The release itself was completed by manually dispatching the same verified workflow.

Validation: the branch is one commit and the diff is exactly one workflow line.