### PR TITLE
[release] prepare v1.2.2

### DIFF
--- a/.github/workflows/prepare-runner.yml
+++ b/.github/workflows/prepare-runner.yml
@@ -10,7 +10,7 @@ on:
       release_tag:
         description: Draft GitHub release tag to prepare
         required: true
-        default: v1.2.1
+        default: v1.2.2
         type: string
   pull_request:
     branches:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ on:
       release_tag:
         description: Existing tag and draft GitHub release to publish
         required: true
-        default: v1.2.1
+        default: v1.2.2
         type: string
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 Unreleased
+
+1.2.2 (17 July 2026)
+- Restore automatic Runner downloads with newly versioned immutable release coordinates
+- Rebuild the canonical ZXing 3.5.4 Runner and publish synchronized Python and conda metadata
 - Reorganize the English and Chinese README files and add versioned Sphinx documentation for Read the Docs
 
 1.2.1 (17 July 2026)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -3,8 +3,8 @@
 {% set runner_version = "1.2.2" %}
 {% set zxing_version = "3.5.4" %}
 {% set runner_filename = "pyzxing-runner-1.2.2-zxing-3.5.4.jar" %}
-{% set runner_sha256 = "0000000000000000000000000000000000000000000000000000000000000000" %}
-{% set runner_source_commit = "" %}
+{% set runner_sha256 = "a132a7762297e66d92683c6c5d2ef135a05f8be382798be6e7fa39254f0b5455" %}
+{% set runner_source_commit = "1792fa369a923fb133e98e62b160423a4367998d" %}
 
 package:
   name: {{ name|lower }}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,10 @@
 {% set name = "pyzxing" %}
-{% set version = "1.2.1" %}
-{% set runner_version = "1.2.1" %}
+{% set version = "1.2.2" %}
+{% set runner_version = "1.2.2" %}
 {% set zxing_version = "3.5.4" %}
-{% set runner_filename = "pyzxing-runner-1.2.1-zxing-3.5.4.jar" %}
-{% set runner_sha256 = "4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565" %}
-{% set runner_source_commit = "4e94d9d61fc0dbe7c4616a620ee961d3a3f2c438" %}
+{% set runner_filename = "pyzxing-runner-1.2.2-zxing-3.5.4.jar" %}
+{% set runner_sha256 = "0000000000000000000000000000000000000000000000000000000000000000" %}
+{% set runner_source_commit = "" %}
 
 package:
   name: {{ name|lower }}

--- a/java-runner/pom.xml
+++ b/java-runner/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.chenjiexu</groupId>
   <artifactId>pyzxing-runner</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>pyzxing JSONL Runner</name>
   <description>Machine-readable ZXing runner for pyzxing</description>
 

--- a/pyzxing/__version__.py
+++ b/pyzxing/__version__.py
@@ -1,6 +1,6 @@
 """Version information for pyzxing package."""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 # For backward compatibility
 VERSION = __version__

--- a/pyzxing/config.py
+++ b/pyzxing/config.py
@@ -14,14 +14,14 @@ class Config:
     MIN_PYTHON_VERSION = '>=3.8.0'
     
     # pyzxing Runner / ZXing settings
-    RUNNER_VERSION = '1.2.1'
+    RUNNER_VERSION = '1.2.2'
     DEFAULT_ZXING_VERSION = '3.5.4'
     JAR_RELEASE_VERSION = RUNNER_VERSION
     JAR_URL_PREFIX = "https://github.com/ChenjieXu/pyzxing/releases/download/v{version}/"
-    JAR_FILENAME = "pyzxing-runner-1.2.1-zxing-3.5.4.jar"
+    JAR_FILENAME = "pyzxing-runner-1.2.2-zxing-3.5.4.jar"
     # PRE-RELEASE GATE: replace both placeholders from the canonical draft asset.
-    JAR_SHA256 = "4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565"
-    RUNNER_SOURCE_COMMIT = "4e94d9d61fc0dbe7c4616a620ee961d3a3f2c438"
+    JAR_SHA256 = "0000000000000000000000000000000000000000000000000000000000000000"
+    RUNNER_SOURCE_COMMIT = ""
     
     # Performance settings
     PARALLEL_THRESHOLD = 3  # Files below this count use sequential processing

--- a/pyzxing/config.py
+++ b/pyzxing/config.py
@@ -20,8 +20,8 @@ class Config:
     JAR_URL_PREFIX = "https://github.com/ChenjieXu/pyzxing/releases/download/v{version}/"
     JAR_FILENAME = "pyzxing-runner-1.2.2-zxing-3.5.4.jar"
     # PRE-RELEASE GATE: replace both placeholders from the canonical draft asset.
-    JAR_SHA256 = "0000000000000000000000000000000000000000000000000000000000000000"
-    RUNNER_SOURCE_COMMIT = ""
+    JAR_SHA256 = "a132a7762297e66d92683c6c5d2ef135a05f8be382798be6e7fa39254f0b5455"
+    RUNNER_SOURCE_COMMIT = "1792fa369a923fb133e98e62b160423a4367998d"
     
     # Performance settings
     PARALLEL_THRESHOLD = 3  # Files below this count use sequential processing

--- a/reports/issue-34-gb18030.json
+++ b/reports/issue-34-gb18030.json
@@ -28,10 +28,10 @@
     "payload_hex": "c9fab2fad0edbfc9d6a4bac5a3bab2e2cad42d313233"
   },
   "decoder": {
-    "runner_version": "1.2.1",
+    "runner_version": "1.2.2",
     "zxing_version": "3.5.4",
-    "artifact": "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
-    "artifact_sha256": "4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565",
+    "artifact": "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
+    "artifact_sha256": "a132a7762297e66d92683c6c5d2ef135a05f8be382798be6e7fa39254f0b5455",
     "java": "openjdk 17.0.19"
   },
   "cases": {

--- a/reports/issue-35-assessment.json
+++ b/reports/issue-35-assessment.json
@@ -69,10 +69,10 @@
   ],
   "attachment_retention": "source_url_and_sha256_only_not_committed",
   "decoder": {
-    "runner_version": "1.2.1",
+    "runner_version": "1.2.2",
     "zxing_version": "3.5.4",
-    "artifact": "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
-    "artifact_sha256": "4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565",
+    "artifact": "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
+    "artifact_sha256": "a132a7762297e66d92683c6c5d2ef135a05f8be382798be6e7fa39254f0b5455",
     "protocol": "UTF-8 JSONL schema_version 1"
   },
   "hint_matrix": {
@@ -80,7 +80,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
         "{attachment_file_uri}"
       ],
       "hints": {
@@ -94,7 +94,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--try-harder"
       ],
@@ -109,7 +109,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--possible-formats",
         "CODE_39"
@@ -127,7 +127,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--try-harder",
         "--possible-formats",
@@ -146,7 +146,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--pure-barcode"
       ],
@@ -161,7 +161,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--multi",
         "--try-harder"
@@ -177,7 +177,7 @@
       "command": [
         "java",
         "-jar",
-        "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+        "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
         "{attachment_file_uri}",
         "--multi",
         "--try-harder",

--- a/reports/issue-38-zxing-comparison.json
+++ b/reports/issue-38-zxing-comparison.json
@@ -1038,35 +1038,35 @@
     },
     "zxing_3_5_4": {
       "zxing_version": "3.5.4",
-      "runner_version": "1.2.1",
+      "runner_version": "1.2.2",
       "protocol": "UTF-8 JSONL schema_version 1",
-      "artifact": "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
-      "artifact_sha256": "4eafc795f2474b50bf7b01d416e8890578926fcc6f9a64e83543471b95ea3565",
+      "artifact": "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
+      "artifact_sha256": "a132a7762297e66d92683c6c5d2ef135a05f8be382798be6e7fa39254f0b5455",
       "commands": {
         "default": [
           "java",
           "-jar",
-          "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+          "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
           "{input_uri}"
         ],
         "try_harder": [
           "java",
           "-jar",
-          "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+          "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
           "{input_uri}",
           "--try-harder"
         ],
         "pure_barcode": [
           "java",
           "-jar",
-          "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+          "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
           "{input_uri}",
           "--pure-barcode"
         ],
         "qr_only": [
           "java",
           "-jar",
-          "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+          "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
           "{input_uri}",
           "--possible-formats",
           "QR_CODE"
@@ -1074,7 +1074,7 @@
         "wrapper_defaults": [
           "java",
           "-jar",
-          "pyzxing-runner-1.2.1-zxing-3.5.4.jar",
+          "pyzxing-runner-1.2.2-zxing-3.5.4.jar",
           "{input_uri}",
           "--multi",
           "--try-harder"

--- a/tests/test_create_reader.py
+++ b/tests/test_create_reader.py
@@ -50,12 +50,12 @@ def test_missing_java_has_actionable_error(monkeypatch, tmp_path):
 
 
 def test_runner_release_coordinates_are_versioned():
-    assert Config.RUNNER_VERSION == "1.2.1"
+    assert Config.RUNNER_VERSION == "1.2.2"
     assert Config.DEFAULT_ZXING_VERSION == "3.5.4"
-    assert Config.JAR_FILENAME == "pyzxing-runner-1.2.1-zxing-3.5.4.jar"
+    assert Config.JAR_FILENAME == "pyzxing-runner-1.2.2-zxing-3.5.4.jar"
     assert Config.get_jar_url() == (
-        "https://github.com/ChenjieXu/pyzxing/releases/download/v1.2.1/"
-        "pyzxing-runner-1.2.1-zxing-3.5.4.jar"
+        "https://github.com/ChenjieXu/pyzxing/releases/download/v1.2.2/"
+        "pyzxing-runner-1.2.2-zxing-3.5.4.jar"
     )
 
 


### PR DESCRIPTION
## Summary

- advance PyZXing and the Java Runner to v1.2.2 while retaining ZXing 3.5.4
- restore automatic Runner downloads under the new immutable `v1.2.2` release coordinates
- bind Python and conda metadata to one reproducible canonical Runner
- carry the synchronized documentation and durable issue evidence into the patch release

## Runner provenance

- frozen source commit: `1792fa369a923fb133e98e62b160423a4367998d`
- canonical SHA-256: `a132a7762297e66d92683c6c5d2ef135a05f8be382798be6e7fa39254f0b5455`
- preparation workflow: https://github.com/ChenjieXu/pyzxing/actions/runs/29582471099
- staging draft: `runner-assets-v1.2.2-1792fa369a923fb133e98e62b160423a4367998d`

The GitHub workflow built the frozen Java source twice in separate clean jobs and required both JARs and checksum files to be byte-identical before creating the four staging assets. The downloaded canonical bytes also match both local clean builds.

## Verification

- 11 Java tests in each clean Maven build
- 101 Python tests on Python 3.8
- 80% Python coverage
- synchronized version and release-evidence checks
- Ruff, Actionlint, and Zizmor
- wheel and sdist build plus Twine metadata checks
- clean wheel and sdist installs with real Java 17 decode
- Python 3.14 one-file PyInstaller build with bundled Runner and real decode
- Sphinx 9.1 documentation build with warnings treated as errors

## Merge and publication

This release PR must use GitHub's normal **Create a merge commit** method. Do not squash or rebase it: the frozen Runner source commit must remain an ancestor of the default-branch merge commit.

The public `v1.2.2` tag, GitHub Release, PyPI upload, and conda-forge update remain intentionally deferred until this PR is merged and the exact push-triggered default-branch CI run succeeds.
